### PR TITLE
Validation Cleanup and ARD Import Fixes

### DIFF
--- a/app/models/manifest/computer.rb
+++ b/app/models/manifest/computer.rb
@@ -13,7 +13,10 @@ class Computer < ActiveRecord::Base
   # Validations
   validate :computer_model
   validates_presence_of :name, :hostname, :mac_address
-  validates_format_of :hostname, :with => /^[a-zA-Z0-9-]+$/, :message => "must only contain alphanumeric and hyphens characters"
+  
+  validates_format_of :hostname,
+                      :with => /(?=^.{1,254}$)(^(?:(?!\d+\.|-)[a-zA-Z0-9_\-]{1,63}(?<!-)\.?)+(?:[a-zA-Z]{2,})$)/, 
+                      :message => "must only contain alphanumeric and hyphens characters" #This will match any valid DNS FQDN
     
   validates_format_of :mac_address, :with => /^([0-9a-f]{2}(:|$)){6}$/ # mac_address attribute must look something like ff:12:ff:34:ff:56
   validates_uniqueness_of :mac_address,:name, :hostname

--- a/app/models/service/computer_service.rb
+++ b/app/models/service/computer_service.rb
@@ -77,6 +77,7 @@ class ComputerService
         # then the template setting is applied
         c = Computer.new({:mac_address => computer_info["hardwareAddress"],
                           :name => computer_info["name"],
+                          :hostname => computer_info["hostname"],
                           :unit_id => unit.id,
                           :environment_id => environment_id})
         c.computer_group = cg


### PR DESCRIPTION
Cleaning up hostname, name and mac address validations and expanding the hostname regex. Hostnames are now being imported via the ARD import.
