### PR TITLE
Fix for undefined method `latest?' in the Package model

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -443,7 +443,7 @@ class Package < ActiveRecord::Base
   def to_s(style = nil)    
     case style
     when :unique then
-      if latest?
+      if latest_in_unit?
         "#{id}_#{name}"
       else
         "#{id}_#{name}-#{version}"


### PR DESCRIPTION
This commit fixes what I think is a bug. I received the error below and determined that 'latest_in_unit?' is the correct method to be called (I think...).
## Error Message

Started GET "/Communication/packages/CSPremium55updater" for xxx.xxx.xxx.xxx at 2011-07-19 12:57:52 -0400
  Processing by PackagesController#show as HTML
  Parameters: {"unit"=>"Communication", "package_branch"=>"CSPremium55updater"}
Rendered shared/_record_header.html.erb (0.9ms)
Rendered packages/show.html.erb within layouts/application (158.3ms)
Completed   in 401ms

ActionView::Template::Error (undefined method `latest?' for #<Package:0x00000105f89c50>):
    51:             <td><strong>Update for</strong></td>
    52:             <td>
    53:                 <% @package.update_for.each do |p| %>
    54:                     <%= p.to_s(:unique) %><br />
    55:                 <% end %>
    56:             </td>
    57:         </tr>
  app/models/package.rb:447:in`to_s'
  app/views/packages/show.html.erb:54:in `block in _app_views_packages_show_html_erb__2915967553736801744_2196959400_3956084679060079867'
  app/views/packages/show.html.erb:53:in`each'
  app/views/packages/show.html.erb:53:in `_app_views_packages_show_html_erb__2915967553736801744_2196959400_3956084679060079867'
  app/controllers/packages_controller.rb:16:in`show'
