### PR TITLE
Add digested email package notifications

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -231,4 +231,8 @@ module ApplicationHelper
     controller = "computers" unless included_controllers.include?(controller)
     {:controller => controller, :action => :index, :unit_shortname => unit.to_param}
   end
+  
+  def macupdate_url(package)
+    macupdate_url = VersionTracker::MAC_UPDATE_PACKAGE_URL + package.package_branch.version_tracker.web_id.to_s
+  end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -16,6 +16,13 @@ class AdminMailer < ActionMailer::Base
     mail(:bcc => recipients(@package), :subject => "[Munki Server] #{@package.to_s(:pretty)} has an update! ")
   end
   
+  def packages_update_available(packages, unit, email)
+    @packages = packages
+    # @version_tracker = @package.package_branch.version_tracker
+    # @macupdate_url = VersionTracker::MAC_UPDATE_PACKAGE_URL + @version_tracker.web_id.to_s
+    mail(:bcc => email, :subject => "[Munki Server] #{@packages.count} packages have update in #{unit.name}! ")
+  end
+  
   def warranty_report(computer)
     @computer = computer
     mail(:bcc => recipients(@computer), :subject => "[Munki Server] #{@computer}'s warranty will expire in #{@computer.warranty_days_left} days")

--- a/app/views/admin_mailer/packages_update_available.html.erb
+++ b/app/views/admin_mailer/packages_update_available.html.erb
@@ -1,0 +1,26 @@
+<% @packages.each do |package| %>
+	<h3>
+		<%= package.to_s(:pretty) %> version <%= package.package_branch.version_tracker.version %> is now available!
+	</h3>
+
+	<p>The current version is <%= link_to package.to_s(:pretty_with_version), package_url(package.to_params)%></p>
+
+	<p><%= link_to "Click here to add", new_package_url(package.unit) %> to add a package to <%= package.unit %> unit</p>
+
+	<% if package.package_branch.version_tracker.download_links.present? %>
+		<div>
+			<p><strong>Download Links</strong></p>
+			<div>
+				<ul>
+				<% package.package_branch.version_tracker.download_links.each_with_index do |download_link,i| %>
+					<li>
+						<%= link_to "#{download_link.text}", download_link.url  , :target => "_blank" %> - <%= download_link.caption %>
+					</li>
+				<% end %>
+				</ul>
+			</div>
+		</div>
+	<% end %>
+
+<p>For more details: <%= link_to macupdate_url(package), macupdate_url(package) %></p>
+<% end %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,6 +3,6 @@
 
 # default rails enviroment set to production, when deploy need to remove development settings
 every 1.day, :at => '11:00pm' do  
-  rake "packages:send_update_notifications"
+  rake "packages:send_digested_update_notifications"
   rake "warranties:update_all"
 end

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -5,12 +5,25 @@ namespace :packages do
   end
   
   
-  desc "Check macupdate.com for available updates and notify Admins"
+  desc "Check macupdate.com for available updates and notify Admins (one email per package)"
   task :send_update_notifications => :environment do
     VersionTracker.update_all
     
     PackageBranch.available_updates.each do |package|
       AdminMailer.package_update_available(package).deliver
+    end
+  end
+  
+  desc "Send digested package update notifications one mail with multiple available update packages"
+  task :send_digested_update_notifications => :environment do
+    VersionTracker.update_all
+    units = Unit.all
+    units.each do |unit|
+      # Find packages have updates in a given unit
+      packages = PackageBranch.available_updates(unit)
+      User.all.each do |user|
+        AdminMailer.packages_update_available(packages, unit, user.email).deliver
+      end
     end
   end
   


### PR DESCRIPTION
Add digested email package notifications, this will send one email contains all the available update packages within a  unit a user is belong to.
