### PR TITLE
User no-longer requires units to show add_computer widget. Fixes #73.

### DIFF
--- a/app/models/widgets/add_computer_widget.rb
+++ b/app/models/widgets/add_computer_widget.rb
@@ -1,3 +1,2 @@
 class AddComputerWidget < DashboardWidget
-  # Get missing manifests for display in the widget
 end

--- a/app/views/widgets/_add_computer.html.erb
+++ b/app/views/widgets/_add_computer.html.erb
@@ -1,3 +1,5 @@
-<%= form_for(Computer.new, :url => computers_path(current_user.units.first), :html => {:multipart => true, :id => "add_computer_widget_form"}) do |f| %>
-	<%= render :partial => 'computers/add_computer_short_form', :locals => {:f => f, :computer => Computer.new, :submit_value => "Add"} %>
+<%  if current_user.units.present? %>
+	<%= form_for(Computer.new, :url => computers_path(current_user.units.first), :html => {:multipart => true, :id => "add_computer_widget_form"}) do |f| %>
+		<%= render :partial => 'computers/add_computer_short_form', :locals => {:f => f, :computer => Computer.new, :submit_value => "Add"} %>
+	<% end %>
 <% end %>


### PR DESCRIPTION
Fixing a bug where a user MUST have units, in order to see the add_computer widget.
