### PR TITLE
Don't call a method on u before u is instantiated

### DIFF
--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -183,7 +183,7 @@ namespace :bootstrap do
       Rake::Task["bootstrap:environments"].invoke if Environment.count == 0
       name = args.name
       name ||= "Default"
-      u = Unit.new(:name => name, :shortname => u.conform_name_to_shortname, :description => "Created by bootstrap")
+      u = Unit.new(:name => name, :description => "Created by bootstrap")
       unless u.save
         puts "Default unit failed to save: " + u.errors.inspect
       end


### PR DESCRIPTION
In line 186 of lib/tasks/bootstrap.rake while u is being instantiated u.conform_name_to_shortname is being called.

This is redundante since the shortname gets automatically set when assigning the name of a Unit.
