### PR TITLE
Addressing issue #118 with two new rake tasks and more whenever tasks.  Fixing #118

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,8 +1,17 @@
 # Use this file to easily define all of your cron jobs.
-# run take task to check for updates every night at 11 pm
 
 # default rails enviroment set to production, when deploy need to remove development settings
+
+# run rake tasks to check for updates every night at 11 pm
 every 1.day, :at => '11:00pm' do  
   rake "packages:send_available_update_digest"
   rake "warranties:update_all"
+end
+
+# run rake tasks to cleanup old system profiles, managed install reports, and missing manifets
+# every night at 12 pm 
+every 1.day, :at => '2:00am' do
+  rake "chore:cleanup_system_profiles"
+  rake "chore:cleanup_old_managed_install_report"
+  rake "chore:cleanup_missing_manifests"
 end

--- a/lib/tasks/chore.rake
+++ b/lib/tasks/chore.rake
@@ -1,4 +1,18 @@
 namespace :chore do
+  desc "Removes MissingManifests created after X days ago (defaults to 30 days)"  
+  task :cleanup_missing_manifests, [:days_kept] => [:environment] do
+    args.with_defaults(:days_kept => 30)
+    results = MissingManifest.where("created_at < :date", :date => (Date.today - args[:days_kept].to_i.days)).destroy_all
+    puts "Destroyed #{results.count} missing manifests"
+  end
+  
+  desc "Removes ManagedInstallReports created after X days ago (defaults to 30 days)"
+  task :cleanup_old_managed_install_reports, [:days_kept] => [:environment] do |t, args|
+    args.with_defaults(:days_kept => 30)
+    results = ManagedInstallReport.where("created_at < :date", :date => (Date.today - args[:days_kept].to_i.days)).destroy_all
+    puts "Destroyed #{results.count} managed install reports"
+  end
+  
   desc "Removes all unused (unreferenced) SystemProfile records."
   task :cleanup_system_profiles => :environment do
     results = SystemProfile.unused.map(&:destroy)


### PR DESCRIPTION
Added two rake tasks, one to cleanup Missing Manifests past a certain date and Managed Install Reports past a certain date

Also, updating nightly schedule to run these tasks.
