### PR TITLE
If file upload fails , delete file

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -63,6 +63,7 @@ class PackagesController < ApplicationController
         format.html { redirect_to edit_package_path(@package.to_params) }
       else
         # Failure
+        @package.delete_package_file_if_necessary
         flash[:error] = "Failed to add package"
         flash[:error] = flash[:error] + ": " + exceptionMessage if exceptionMessage.present?
         format.html { render :action => "new"}


### PR DESCRIPTION
Made use of the existing method delete_package_file_if_necessary to remove files if an upload fails.  This will prevent orphaned files from being left behind, ie #109
