### PR TITLE
Require iconv on ruby 1.8.x

### DIFF
--- a/config/initializers/extend_string.rb
+++ b/config/initializers/extend_string.rb
@@ -1,3 +1,4 @@
+require 'iconv' unless RUBY_VERSION =~ /^1\.9/
 class String
   def each(&block)
     self.each_line(&block)


### PR DESCRIPTION
Make sure iconv is loaded/required when using Ruby 1.8.x
