### PR TITLE
Fix sending update email (closes #151)

### DIFF
--- a/app/models/package_branch.rb
+++ b/app/models/package_branch.rb
@@ -159,11 +159,11 @@ class PackageBranch < ActiveRecord::Base
     packages_with_updates = []
     if unit.present?
       latest_packages = Package.latest_where_unit(unit)
-      packages_with_updates = latest_packages.delete_if {|p| !p.new_version? }      
+      packages_with_updates = latest_packages.delete_if {|p| p.nil? or !p.new_version? }      
     else
       Unit.all.each do |unit|
         latest_packages = Package.latest_where_unit(unit)
-        packages_with_updates += latest_packages.delete_if {|p| !p.new_version? }
+        packages_with_updates += latest_packages.delete_if {|p| p.nil? or !p.new_version? }
       end
     end
     packages_with_updates


### PR DESCRIPTION
package_branches that had all their packages deleted cause latest_packages to contain Nil entries, so skip those.
