### PR TITLE
Place client scripts in the right location

### DIFF
--- a/script/munki_scripts/Makefile
+++ b/script/munki_scripts/Makefile
@@ -1,7 +1,7 @@
-PKGMAKER = packagemaker
+PKGMAKER = "$(shell mdfind kMDItemCFBundleIdentifier == com.apple.PackageMaker | head -n 1)/Contents/MacOS/PackageMaker"
 HDIUTIL = hdiutil
 TMPDIR = ./build/munkiserverscripts
-TARGETPATH = /etc/munki
+TARGETPATH = /usr/local/munki
 ID = com.github.jnraine.munkiserver.clientscripts
 PKG_OUT = munkiscripts.pkg
 DMG_OUT = munkiscripts.dmg


### PR DESCRIPTION
Somehow it took me three months to notice that my Makefile puts the {pre,post}flight scripts in the wrong place.
Also, it now uses Spotlight to find PackageMaker as newer versions of Xcode no longer place it in PATH.
