### PR TITLE
Added Homebrew Imagemagick Path to paperclip.rb

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -17,7 +17,7 @@ end
 
 # Check a couple places it may be
 if path.nil?
-  ["/opt/local/bin","/usr/bin"].each do |possible_path|
+  ["/usr/local/bin","/opt/local/bin","/usr/bin"].each do |possible_path|
     path = possible_path if File.exists?(Pathname.new(possible_path) + "identify")
   end
 end


### PR DESCRIPTION
I've added "/usr/local/bin" to the list of paths to be searched in config/initializers/paperclip.rb so that imagemagick is properly found when installed using homebrew.
