### PR TITLE
Add batch delete functionality to Packages and Computers

### DIFF
--- a/app/controllers/computers_controller.rb
+++ b/app/controllers/computers_controller.rb
@@ -179,6 +179,20 @@ class ComputersController < ApplicationController
     p = params[:computer]
     results = []
     exceptionMessage = nil
+
+    if params[:commit] == 'Delete'
+      computercount = params[:selected_records].length
+      params[:selected_records].each do |computer|
+        @computers = Computer.where(:id => params[:selected_records])
+        @computers.each do |this|
+          # results = this.destroy
+          this.destroy
+        end
+      end
+      redirect_to computers_path, :flash => { :notice => "All #{computercount} selected computer records were successfully deleted." }
+      return
+    end
+
     begin
       results = Computer.bulk_update_attributes(@computers, p)
     rescue ComputerError => e

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -80,14 +80,41 @@ class PackagesController < ApplicationController
   def update_multiple
     results = {}
     exceptionMessage = nil
+
+    if params[:commit] == 'Delete'
+      computercount = params[:selected_records].length
+      params[:selected_records].each do |computer|
+        @computers = Computer.where(:id => params[:selected_records])
+        @computers.each do |this|
+          # results = this.destroy
+          this.destroy
+        end
+      end
+      redirect_to computers_path, :flash => { :notice => "All #{computercount} selected computer records were successfully deleted." }
+      return
+    end
+
+    if params[:commit] == 'Delete'
+      packagecount = params[:selected_records].length
+      params[:selected_records].each do |package|
+        @packages = Package.where(:id => params[:selected_records])
+        @packages.each do |this|
+          # results = this.destroy
+          this.destroy
+        end
+      end
+      redirect_to packages_path, :flash => { :notice => "All #{packagecount} selected packages were successfully deleted." }
+      return
+    end
+  
     begin
       @packages = Package.where(:id => params[:selected_records])
       results = Package.bulk_update_attributes(@packages, params[:package])
     rescue PackageError => e
       exceptionMessage = e.to_s
     end
-    
-    respond_to do |format|
+ 
+     respond_to do |format|
       if exceptionMessage
         flash[:error] = "A problem occurred: " + exceptionMessage
       elsif results[:total] == results[:successes] and results[:failures] == 0

--- a/app/views/computers/_edit_multiple.html.erb
+++ b/app/views/computers/_edit_multiple.html.erb
@@ -43,6 +43,7 @@
 			</td>
 			<td>
 				<%= f.submit "Update" %>
+				<%= f.submit "Delete", :confirm => "Are you sure you want to delete these #{@computers.count} computer records?" %>
 				<a href="#" class="cancel">Cancel</a>
 			</td>
 		</tr>

--- a/app/views/packages/_edit_multiple.html.erb
+++ b/app/views/packages/_edit_multiple.html.erb
@@ -104,6 +104,7 @@
 			</td>
 			<td>
 				<%= f.submit "Update" %>
+				<%= f.submit "Delete", :confirm => "Are you sure you want to delete these #{@packages.count} packages?" %>
 				<a href="#" class="cancel">Cancel</a>
 			</td>
 		</tr>


### PR DESCRIPTION
Added batch delete functionality to Packages and Computers. An additional 'Delete' button appears in the 'Edit Selection' form. After deletion the Packages or Computers main index is reloaded.
