### PR TITLE
Preflight script: MAC addresse extraction not specific enough.

### DIFF
--- a/script/munki_scripts/preflight.rb
+++ b/script/munki_scripts/preflight.rb
@@ -3,7 +3,7 @@
 require 'osx/cocoa'
 include OSX
 
-MAC_ADDRESS = `ifconfig en0 | awk '/ether/ {print $2}'`.strip
+MAC_ADDRESS = `ifconfig en0 | awk '$1=="ether" {print $2}'`.strip
 BUNDLE_ID = "ManagedInstalls"
 
 def set_preference(key, value)


### PR DESCRIPTION
Ran across [this](https://code.google.com/p/munki/issues/detail?id=197) issue the other day.
All credit to @jps3 (Jason Stanford)
