### PR TITLE
Add a package branch name dropdown menu to the upload form.

### DIFF
--- a/app/use_cases/process_package_upload.rb
+++ b/app/use_cases/process_package_upload.rb
@@ -34,6 +34,8 @@ class ProcessPackageUpload
     # Checks to ensure what should be present is. If something is missing, raise 
     # Error exception.
     def validate
+      hash[:makepkginfo_options].delete("name") if hash[:makepkginfo_options][:name].blank?
+
       raise Error.new("Please select a file or specify a URL") if hash[:package_file].blank? and hash[:file_url].blank?
       raise Error.new("Must provide a special attributes") if hash[:special_attributes].nil?
       raise Error.new("Must provide a unit ID") if hash[:special_attributes][:unit_id].nil?

--- a/app/views/packages/_add_package_form_contents.html.erb
+++ b/app/views/packages/_add_package_form_contents.html.erb
@@ -19,6 +19,12 @@ Alternatively enter a URL from where to download the .dmg<br />
 		Choose a pkginfo plist <%= helpful_info("Generate a pkginfo plist using makepkginfo and upload it")%><br />
 		<p><%= file_field_tag :pkginfo_file %></p>
 	<% end %>
+<!--	<%= text_field_tag "makepkginfo_options[name]" %> -->
+	<%= collection_select(:makepkginfo_options, :name, PackageBranch.order('display_name'), :name, :display_name, {:include_blank => ''}) %>
+	Name
+	<%= helpful_info("Override the package branch.
+	This is useful if the application or package name contains a version number
+	you do not want to include in the branch name.") %><br />
 	<%= text_field_tag "makepkginfo_options[pkgname]" %> 
 	Package name
 	<%= helpful_info("From makepkginfo help page: If the upload is a disk image containing


### PR DESCRIPTION
This is useful if you want to force a new package to be added to a certain branch (i.e. replace an existing package).
For example, Adobe Reader gets named "Adobe_Reader_XI_Installer". You might have changed this to "Adobe_Reader".
When you now upload a new version, it would again be named "Adobe_Reader_XI_Installer" and you would have no way of moving it to the existing "Adobe_Reader" branch.
This patch fixes the issue by allowing you to specify "Adobe_Reader" before uploading.
If you don't specify anything, the default name as determined by makepkginfo will be used.

I have been running this patch in production for almost two months now and it works fine. I have added many packages to the automatically selected package branch and a couple using the manual branch selection from this patch.
