### PR TITLE
Use IO.copy_stream to copy the package to import.

### DIFF
--- a/app/use_cases/process_package_upload.rb
+++ b/app/use_cases/process_package_upload.rb
@@ -146,7 +146,7 @@ class ProcessPackageUpload
         package_file.tempfile.path = file.path
         
         open(url) do |u|
-          file << u.read
+          IO.copy_stream(u,file)
           file_url_path = u.base_uri.path if u.respond_to?(:base_uri)
           file_url_path ||= URI.parse(url).path
           package_file.original_filename = File.basename(file_url_path)


### PR DESCRIPTION
I recently tried to import a package which always failed with an "Invalid Argument" error message. All other packages could be imported just fine. To fix this, I simply modified `retrieve_file_from_url` to use `IO.copy_stream`.
