### PR TITLE
Postflight issue when using cacerts

### DIFF
--- a/script/munki_scripts/postflight
+++ b/script/munki_scripts/postflight
@@ -29,7 +29,7 @@ def latest_managed_install_report_path():
     
 def ssl_option():
     if cacert_file():
-        return "--cacert \"{1}\"".format(cacert_file())
+        return "--cacert \"{0}\"".format(cacert_file())
     else:
         return ""
 


### PR DESCRIPTION
When a cacert was used, the ssl_option() function would throw the following error:

IndexError: tuple index out of range 

Using 1 as the arg_name requires two arguments to be passed to the format() function. But since we're only passing one, it needs to be changed to 0.
