### PR TITLE
Munki 2 support and some minor fixes

### DIFF
--- a/app/controllers/computers_controller.rb
+++ b/app/controllers/computers_controller.rb
@@ -77,6 +77,12 @@ class ComputersController < ApplicationController
       end
     end
   end
+  
+  def show_resource
+    respond_to do |format|
+      format.zip { render :text => "", :status => 404 }
+    end
+  end
 
   def edit
   end
@@ -237,7 +243,7 @@ class ComputersController < ApplicationController
     action = params[:action].to_sym
     if [:show, :client_prefs].include?(action)      
       @computer = Computer.find_for_show_fast(params[:id], current_unit)
-    elsif [:show_plist].include?(action)      
+    elsif [:show_plist, :show_resource].include?(action)      
       @computer = Computer.find_for_show(nil, params[:id])
     elsif [:edit, :update, :destroy].include?(action)
       @computer = Computer.find_for_show(params[:unit_shortname], CGI::unescape(params[:id]))

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,10 +28,10 @@ class Ability
   # Permit certain things to all requests
   def permit_unprotected_actions
     # Allow clients to download packages
-    can :download, Package
+    can [:download, :icon], Package
     # Allow client computer requests
     can :checkin, Computer
-    can :show_plist, Computer
+    can [:show_plist, :show_resource], Computer
     # Allow any request to retrieve catalogs
     can :read, Catalog
     # Allow everyone to edit their user record

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -54,7 +54,7 @@ class Package < ActiveRecord::Base
   validates :force_install_after_date_string, :date_time => true, :allow_blank => true
 
   FORM_OPTIONS = {:restart_actions         => [['None','None'],['Logout','RequiredLogout'],['Restart','RequiredRestart'],['Shutdown','Shutdown']],
-                  :os_versions             => [[['Any','']], os_range(10,9,0..1), os_range(10,8,0..5), os_range(10,7,0..5), os_range(10,6,0..8), os_range(10,5,0..11)].flatten(1),
+                  :os_versions             => [[['Any','']], os_range(10,10,0..1), os_range(10,9,0..5), os_range(10,8,0..5), os_range(10,7,0..5), os_range(10,6,0..8), os_range(10,5,0..8)].flatten(1),
                   :installer_types         => [['Package',''],
                                                ['Copy From DMG', 'copy_from_dmg'],
                                                ['App DMG','appdmg'],

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -556,6 +556,7 @@ class Package < ActiveRecord::Base
       end
 
       # Add append any special cases to the hash
+      h["category"] = self.package_category.to_s
 
       # Supported Architectures
       sa = self.supported_architectures.delete_if {|e| e == ""}

--- a/app/models/version_tracker.rb
+++ b/app/models/version_tracker.rb
@@ -20,8 +20,12 @@ class VersionTracker < ActiveRecord::Base
   def self.update_all
     branches = PackageBranch.all
     branches.each do |branch|
-      branch.version_tracker.fetch_data
-      branch.save!
+      begin
+        branch.version_tracker.fetch_data
+        branch.save!
+      rescue
+        nil
+      end
     end
   end
   

--- a/app/use_cases/process_package_upload.rb
+++ b/app/use_cases/process_package_upload.rb
@@ -148,6 +148,7 @@ class ProcessPackageUpload
         open(url) do |u|
           IO.copy_stream(u,file)
           file_url_path = u.base_uri.path if u.respond_to?(:base_uri)
+          file_url_path = u.meta['content-disposition'].match(/filename=(\"?)(.+)\1/)[2] if u.respond_to?(:meta) and u.meta.has_key?('content-disposition') and u.meta['content-disposition'].include?('filename=')
           file_url_path ||= URI.parse(url).path
           package_file.original_filename = File.basename(file_url_path)
         end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -157,7 +157,7 @@
 <div class="footer">
 	<div class="container">
 		<p class="span-8 last prepend-8 append-8 text-center">
-			munki server <%= Munki::Application::VERSION %><br>
+			munki server <%= Munki::Application::VERSION %><br />
 			munki tools <%= Munki::Application::MUNKITOOLS_VERSION %>
 		</p>
 		

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,11 @@ Munki::Application.routes.draw do
   match ':id.plist', :controller => 'computers', :action => 'show_plist', :format => 'manifest', :id => /[A-Za-z0-9_\-\.%:]+/, :as => "computer_manifest"
   match 'computers/:id.plist', :controller => 'computers', :action => 'show_plist', :format => 'manifest', :id => /[A-Za-z0-9_\-\.%:]+/
   match 'site_default', :controller => 'computers', :action => 'show_plist', :format => 'manifest', :id => '00:00:00:00:00:00', :as => "computer_manifest"
+  match 'client_resources/:id.plist.zip', :controller => 'computers', :action => 'show_resource', :format => :zip, :id => /[A-Za-z0-9_\-\.%:]+/, :as => "computer_resource"
+  match 'client_resources/site_default.zip', :controller => 'computers', :action => 'show_resource', :format => :zip, :id => '00:00:00:00:00:00', :as => "computer_resource"
   
   match 'pkgs/:id.json' => 'packages#download', :format => :json, :id => /[A-Za-z0-9_\-\.%]+/
+  match 'icons/:package_branch.png' => 'packages#icon', :format => :png, :package_branch => /[A-Za-z0-9_\-\.%]+/
   match 'catalogs/:unit_environment' => 'catalogs#show', :format => 'plist', :via => :get
   match 'pkgs/:id' => 'packages#download', :as => 'download_package', :id => /[A-Za-z0-9_\-\.%]+/
   match '/configuration/:id.plist', :controller => 'computers', :action => 'show', :format => 'client_prefs', :id => /[A-Za-z0-9_\-\.:]+/


### PR DESCRIPTION
Support [Munki 2](http://managingosx.wordpress.com/2014/09/17/munki-2-released/)'s new features:
- Provide the package icon at the expected path
- Include the packages categories in the catalog
- 404 the client_resources ZIP file (for now)

Other:
- Extract the Content-disposition filename field for files pulled from a URL
- OS Versions array extended to 10.9.5 and 10.10
- Prevent an exception in version_tracker
- Fix XML compliance of HTML